### PR TITLE
Feat: ID探しAPI, ログインページに戻るボタン Rename: ログインページのフォルダ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import { Route, Routes } from "react-router-dom";
-import Login from "./pages/Login";
+import Login from "./pages/auth/Login";
 import Main from "./pages/Main";
-import Join from "./pages/Join";
-import FindMyAccount from "./pages/FindMyAccount";
+import Join from "./pages/auth/Join";
+import FindMyAccount from "./pages/auth/FindMyAccount";
 import Mypage from "./pages/Mypage";
 import Master from "./pages/Master";
 import Management from "./components/master/Management";
 import Salon from "./pages/Salon";
 import SalonPending from "./pages/SalonPending";
-import PriceCorrection from "./components/salon/PriceCorrection";
 import SalonPrice from "./pages/SalonPrice";
+import FindResult from "./pages/auth/FindResult";
 
 function App() {
   return (
@@ -19,6 +19,7 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/join" element={<Join />} />
         <Route path="/findIdPw" element={<FindMyAccount />} />
+        <Route path="/findIdPw/result" element={<FindResult />} />
         <Route path="/main" element={<Main />}>
           <Route path="mypage" element={<Mypage />} />
           <Route path="master" element={<Master />} />

--- a/src/components/auth/GetResult.tsx
+++ b/src/components/auth/GetResult.tsx
@@ -1,0 +1,31 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { ListBtn } from "../master/UserList";
+
+function GetResult() {
+  const location = useLocation();
+  const userData = location.state.user;
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col gap-14 bg-sky-200/90 rounded-3xl aspect-video p-10 min-w-96 max-w-fit m-auto">
+      <div className="text-xl font-bold">
+        <span className="text-3xl text-blue-800">{userData.name}</span>님의
+        이메일은{" "}
+      </div>
+      <div className="font-bold text-5xl border-b-4 border-b-black pb-4">
+        {userData.email}
+      </div>
+      <div className="text-center">
+        <ListBtn
+          value="확인"
+          color="bg-red-500"
+          onClick={() => {
+            navigate("/login");
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default GetResult;

--- a/src/components/auth/JoinForm.tsx
+++ b/src/components/auth/JoinForm.tsx
@@ -6,6 +6,7 @@ import { trimValues } from "../../utils/validate";
 import { customAxios } from "../../services/customAxios";
 import { emailReg, nameReg, passwordReg, phoneNumReg } from "../../utils/regex";
 import { useNavigate } from "react-router-dom";
+import CloseIcon from "../../icons/CloseIcon";
 
 function JoinForm(): JSX.Element {
   const {
@@ -29,16 +30,16 @@ function JoinForm(): JSX.Element {
   // 아이디 중복 체크 함수
   const idDuplicateCheck = async (email: string) => {
     const isValid = emailReg.test(email);
-
     if (!isValid) {
       return Promise.reject(new Error("이메일을 입력해주세요."));
     }
     //중복체크 API
     const verifyEmail = await customAxios.get(
-      `api/admin/verify-email/${email}`
+      `/api/admin/verify-email/${email}`
     );
     if (verifyEmail.data.check) {
       setDuplicateCheck(verifyEmail.data.check);
+      console.log(verifyEmail.data.check);
     } else {
       alert("존재하는 이메일입니다.");
     }
@@ -67,7 +68,14 @@ function JoinForm(): JSX.Element {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <div className="flex flex-col bg-sky-200/90 rounded-3xl aspect-video p-10 min-w-96 max-w-xl m-auto">
+      <div className="relative flex flex-col bg-sky-200/90 rounded-3xl aspect-video p-10 min-w-96 max-w-xl m-auto">
+        <div className="absolute right-0 top-0">
+          <CloseIcon
+            onClick={() => {
+              navigate("/login");
+            }}
+          />
+        </div>
         <p className="font-bold text-3xl text-center mb-10 mt-2">회원가입</p>
         <FormInput
           type="text"

--- a/src/pages/auth/FindMyAccount.tsx
+++ b/src/pages/auth/FindMyAccount.tsx
@@ -1,5 +1,5 @@
-import AuthBg from "../components/auth/AuthBg";
-import FindMyAccountForm from "../components/auth/FindMyAccountForm";
+import AuthBg from "../../components/auth/AuthBg";
+import FindMyAccountForm from "../../components/auth/FindMyAccountForm";
 
 function FindMyAccount() {
   return (

--- a/src/pages/auth/FindResult.tsx
+++ b/src/pages/auth/FindResult.tsx
@@ -1,0 +1,12 @@
+import AuthBg from "../../components/auth/AuthBg";
+import GetResult from "../../components/auth/GetResult";
+
+function FindResult() {
+  return (
+    <div>
+      <AuthBg form={<GetResult />} />
+    </div>
+  );
+}
+
+export default FindResult;

--- a/src/pages/auth/Join.tsx
+++ b/src/pages/auth/Join.tsx
@@ -1,5 +1,5 @@
-import AuthBg from "../components/auth/AuthBg";
-import JoinForm from "../components/auth/JoinForm";
+import AuthBg from "../../components/auth/AuthBg";
+import JoinForm from "../../components/auth/JoinForm";
 
 function Join(): JSX.Element {
   return (

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,5 +1,5 @@
-import AuthBg from "../components/auth/AuthBg";
-import LoginForm from "../components/auth/LoginForm";
+import AuthBg from "../../components/auth/AuthBg";
+import LoginForm from "../../components/auth/LoginForm";
 
 function Login(): JSX.Element {
   return (


### PR DESCRIPTION
## 📣 연관된 이슈
> ex) #3 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
>ID探しAPIを適用し、探したIDを表示するページを追加しました。
ID 찾기 API를 적용하고 찾은 ID를 보여주는 페이지를 추가
>ログイン関連ページにログインページに戻るボタンを追加しました。
로그인 관련 페이지에 로그인 페이지로 돌아갈 수 있는 버튼을 추가
>ログインページのフォルダを整理しました。
로그인 페이지 관련 폴더를 정리

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
