### PR TITLE
feat: メインページのアクセス権に応じたページ遷移機能を追加, Design: アプリケーション全体のフォント変更

### DIFF
--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import Header from "../components/Header";
 import Sidebar from "../components/sidebar/Sidebar";
 import { useEffect } from "react";
@@ -11,14 +11,28 @@ import {
 } from "../recoil/UserDataAtiom";
 
 function Main() {
+  const navigate = useNavigate();
+  const location = useLocation(); // 현재 위치 정보를 가져옴
   // 로그인 상태 전역 변수
   const loginState = useRecoilValue(LoginStateAtom);
   // 로그인 상태 전역 저장변수
   const setLoginState = useSetRecoilState(LoginStateAtom);
+  // 유저 데이터 전역 변수
+  const userData = useRecoilValue(UserDataAtom);
   // 유저 데이터 전역 저장 변수
   const setUserData = useSetRecoilState(UserDataAtom);
   // 로딩 페이지 전역 저장 변수
   const setLoadingState = useSetRecoilState(LoadinStateAtom);
+
+  useEffect(() => {
+    if (location.pathname === "/main" || location.pathname === "/main/") {
+      if (userData.power[0]) {
+        navigate(`/main/${userData.power[0]}`);
+      } else {
+        navigate(`/main`);
+      }
+    }
+  }, [userData]);
 
   // 페이지 새로고침할 시
   useEffect(() => {
@@ -26,9 +40,6 @@ function Main() {
       getUserData().then(() => {
         setLoginState(true);
       });
-      const token = sessionStorage.getItem("userToken");
-      if (token) {
-      }
     }
   }, [loginState]);
 
@@ -37,7 +48,6 @@ function Main() {
     setLoadingState(true);
     try {
       const userData = await privateApi.get("/api/user");
-      console.log(userData.data.admin);
       const data = userData.data.admin;
       const powerArr: string[] = [];
       data.privileges.map((v: { privilege: string }) => {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -13,3 +13,15 @@
 ::-webkit-scrollbar-thumb {
   background-color: transparent;
 }
+
+@font-face {
+  font-family: "Pretendard-Regular";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
+    format("woff");
+  font-weight: 400;
+  font-style: normal;
+}
+
+:root {
+  font-family: "Pretendard-Regular";
+}


### PR DESCRIPTION
## 📣 연관된 이슈
> #2 #3 


## 📝 작업 내용
> 한국어
1. 메인페이지에서 권한에 맞는 페이지로 이동
2. 웹 페이지 전체 글꼴 변경


> 일본어
1. メインページから異なるページへ自動的に遷移する機能を追加しました。
2. 全体のフォントを新しいデザインに変更しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

