### PR TITLE
Fix: リフレッシュエラーを解決

### DIFF
--- a/src/services/customAxios.ts
+++ b/src/services/customAxios.ts
@@ -8,6 +8,7 @@ export const publicApi: AxiosInstance = axios.create({
 // 토큰 보낼 때
 export const privateApi: AxiosInstance = axios.create({
   baseURL: process.env.REACT_APP_SERVER_URI,
+  withCredentials: false,
 });
 
 // 헤더에 엑세스 토큰 추가하기
@@ -33,7 +34,7 @@ privateApi.interceptors.response.use(
           withCredentials: true,
         });
         if (tokenRes.status === 200) {
-          const newAccessToken = tokenRes.data.token;
+          const newAccessToken = tokenRes.data.access_token;
           sessionStorage.setItem("userToken", newAccessToken);
           return axios(originalRequest);
         }


### PR DESCRIPTION
## 📣 연관된 이슈
> X


## 📝 작업 내용
> 한국어
1. 리프레시 토큰 발급 시, 키 값 설정 오류로 인해 토큰이 갱신되지 않던 문제를 해결하였습니다.
2. withCredentials 옵션을 false로 설정하여, 일반 요청에는 쿠키가 담기지 않도록 명시하였습니다.


> 일본어
1. リフレッシュトークンの発行時に、キー値の設定エラーによりトークンが更新されない問題を解決しました。
2. withCredentialsオプションをfalseに設定して、通常のリクエストではクッキーが含まれないようにしました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

